### PR TITLE
add internal onCaughtUp API

### DIFF
--- a/test/helpers/replicate.js
+++ b/test/helpers/replicate.js
@@ -28,4 +28,8 @@ module.exports = async function replicate(person1, person2) {
       }
     }, 100)
   })
+  await Promise.all([
+    p(person1.tribes2.onCaughtUp)(),
+    p(person2.tribes2.onCaughtUp)(),
+  ])
 }


### PR DESCRIPTION
## Context

This is an alternative to #20.

## Problem

There is a race condition between the processing of messages in `start()` and the `list()` API. `list()` is _supposed_ to have all the up-to-date information, but by just querying ssb-box2 (and ssb-keyring), it doesn't, because there may be a message from the live query in `start()` that still hasn't trickled down and made its way to ssb-box2 (and ssb-keyring).

## Solution

We figured (pair programming with @Powersource) that we don't need to strictly solve the race condition in `list()` if we embrace eventual consistency in the apps, but in tests, we need to make strictly solve them, to make the correct assertions.

This PR adds `onCaughtUp(cb)` as an internal API just for our tests. The way it works is a bit hacky, I wanted to use `ssb.db.prepare()` (which in turn is just a light wrapper for jitdb's `prepare()`) but the problem is that `prepare()` only syncs the bitvector indexes, it doesn't fetch the messages from the log (which is an asynchronous operation with the file system). That meant that the processing in `start()` is "slower" than jitdb `prepare()` which would meant that we are not yet caught up.

That's why I added the comment:

```
// This is a bit hacky, because it fixes the race condition with `start()`
// by relying on ssb-db2 internals. This only works because the query in
// `start()` was initiated before this one, and because ssb-db2 and jitdb
// have an internal queue of queries that are executed in order.
```

@arj03 Since you're good at race conditions, and since this is a hacky solution, I'd really appreciate your thoughts on this PR.