### PR TITLE
Use URIs instead of sigils

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const {
   },
 } = require('private-group-spec')
 const { SecretKey } = require('ssb-private-group-keys')
+const { fromMessageSigil } = require('ssb-uri2')
 //const Crut = require('ssb-crut')
 const buildGroupId = require('./lib/build-group-id')
 const AddGroupTangle = require('./lib/add-group-tangle')
@@ -70,7 +71,7 @@ module.exports = {
           const data = {
             id: buildGroupId({ groupInitMsg, groupKey: groupKey.toBuffer() }),
             secret: groupKey.toBuffer(),
-            root: groupInitMsg.key,
+            root: fromMessageSigil(groupInitMsg.key),
             subfeed: '',
           }
 

--- a/index.js
+++ b/index.js
@@ -22,9 +22,7 @@ const {
   },
 } = require('private-group-spec')
 const { SecretKey } = require('ssb-private-group-keys')
-const { fromMessageSigil, fromFeedSigil } = require('ssb-uri2')
-const ref = require('ssb-ref')
-//const Crut = require('ssb-crut')
+const { fromMessageSigil, fromFeedSigil, isFeedSSBURI } = require('ssb-uri2')
 const buildGroupId = require('./lib/build-group-id')
 const AddGroupTangle = require('./lib/add-group-tangle')
 const prunePublish = require('./lib/prune-publish')
@@ -126,9 +124,11 @@ module.exports = {
       get(groupId, (err, { secret, root }) => {
         if (err) return cb(err)
 
-        const feedIdUris = feedIds.map((feedId) =>
-          ref.isFeedId(feedId) ? fromFeedSigil(feedId) : feedId
-        )
+        const feedIdUris = feedIds
+          .map((feedId) =>
+            isFeedSSBURI(feedId) ? feedId : fromFeedSigil(feedId)
+          )
+          .filter(Boolean)
 
         const recps = [groupId, ...feedIdUris]
 

--- a/lib/add-group-tangle.js
+++ b/lib/add-group-tangle.js
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const { isCloakedMsg } = require('ssb-ref')
 const set = require('lodash.set')
+const { isIdentityGroupSSBURI } = require('ssb-uri2')
 const GetGroupTangle = require('./get-group-tangle')
 
 module.exports = function AddGroupTangle(server) {
@@ -15,15 +15,10 @@ module.exports = function AddGroupTangle(server) {
   return function addGroupTangle(content, cb) {
     if (!content.recps) return cb(null, content)
 
-    if (!isCloakedMsg(content.recps[0])) return cb(null, content)
+    if (!isIdentityGroupSSBURI(content.recps[0])) return cb(null, content)
 
     getGroupTangle(content.recps[0], (err, tangle) => {
-      // NOTE there are two ways an err can occur in getGroupTangle
-      // 1. recps is not a groupId
-      // 2. unknown groupId,
-
-      // Rather than cb(err) here we we pass it on to boxers to see if an err is needed
-      if (err) return cb(null, content)
+      if (err) return cb(err)
 
       set(content, 'tangles.group', tangle)
 

--- a/lib/build-group-id.js
+++ b/lib/build-group-id.js
@@ -7,6 +7,7 @@
 const { unboxKey, DeriveSecret, CloakedMsgId } = require('envelope-js')
 const LABELS = require('envelope-spec/derive_secret/constants.json')
 const { keySchemes } = require('private-group-spec')
+const base64url = require('base64-url')
 
 const bfe = require('ssb-bfe')
 
@@ -33,12 +34,11 @@ module.exports = function buildGroupId({
     }
   }
 
-  const cloakedMsgId = new CloakedMsgId(msgId, readKey)
-    .toString()
-    .replaceAll('/', '_')
-    .replaceAll('+', '-')
+  const cloakedMsgId = base64url.escape(
+    new CloakedMsgId(msgId, readKey).toString()
+  )
 
-  return `ssb:identity/group/${cloakedMsgId}`
+  return `ssb:identity/group/${cloakedMsgId}=`
 }
 
 function fromMsgKey(msg, msgKey) {

--- a/lib/build-group-id.js
+++ b/lib/build-group-id.js
@@ -33,9 +33,12 @@ module.exports = function buildGroupId({
     }
   }
 
-  const cloakedMsgId = new CloakedMsgId(msgId, readKey).toString()
+  const cloakedMsgId = new CloakedMsgId(msgId, readKey)
+    .toString()
+    .replaceAll('/', '_')
+    .replaceAll('+', '-')
 
-  return `%${cloakedMsgId}.cloaked`
+  return `ssb:identity/group/${cloakedMsgId}`
 }
 
 function fromMsgKey(msg, msgKey) {

--- a/lib/get-group-tangle.js
+++ b/lib/get-group-tangle.js
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const { isCloakedMsg: isGroup } = require('ssb-ref')
 const pull = require('pull-stream')
 const Reduce = require('@tangle/reduce')
 const Strategy = require('@tangle/strategy')
+const { isIdentityGroupSSBURI } = require('ssb-uri2')
 
 // for figuring out what "previous" should be for the group
 
@@ -15,7 +15,7 @@ module.exports = function GetGroupTangle(server) {
   const getUpdates = GetUpdates(server)
 
   return function getGroupTangle(groupId, cb) {
-    if (!isGroup(groupId))
+    if (!isIdentityGroupSSBURI(groupId))
       return cb(
         new Error(`get-group-tangle expects valid groupId, got: ${groupId}`)
       )

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ssb-crut": "^4.6.1",
     "ssb-meta-feeds": "~0.30.0",
     "ssb-private-group-keys": "^1.0.0",
+    "ssb-ref": "^2.16.0",
     "ssb-uri2": "^2.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "*.js"
   ],
   "dependencies": {
+    "base64-url": "^2.3.3",
     "envelope-js": "^1.3.2",
     "envelope-spec": "^1.1.0",
     "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "pretty-quick": "^3.1.3",
     "secret-stack": "^6.4.1",
     "ssb-caps": "^1.1.0",
-    "ssb-db2": "^6.2.3",
+    "ssb-db2": "ssbc/ssb-db2#uri-get",
     "ssb-ebt": "^9.1.2",
     "tap-arc": "^0.3.4",
     "tape": "^5.5.3"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ssb-crut": "^4.6.1",
     "ssb-meta-feeds": "~0.30.0",
     "ssb-private-group-keys": "^1.0.0",
-    "ssb-uri2": "^2.4.0"
+    "ssb-uri2": "^2.4.1"
   },
   "devDependencies": {
     "c8": "^7.11.3",
@@ -51,7 +51,7 @@
     "pretty-quick": "^3.1.3",
     "secret-stack": "^6.4.1",
     "ssb-caps": "^1.1.0",
-    "ssb-db2": "ssbc/ssb-db2#master",
+    "ssb-db2": "^6.2.6",
     "ssb-ebt": "^9.1.2",
     "tap-arc": "^0.3.4",
     "tape": "^5.5.3"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "envelope-spec": "^1.1.0",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
-    "private-group-spec": "Powersource/private-group-spec#ssb-uris",
+    "private-group-spec": "^2.0.0",
     "pull-async": "^1.0.0",
     "pull-paramap": "^1.2.2",
     "pull-stream": "^3.6.14",

--- a/package.json
+++ b/package.json
@@ -32,15 +32,16 @@
     "envelope-spec": "^1.1.0",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
-    "private-group-spec": "^1.2.0",
+    "private-group-spec": "Powersource/private-group-spec#ssb-uris",
     "pull-async": "^1.0.0",
     "pull-paramap": "^1.2.2",
     "pull-stream": "^3.6.14",
-    "ssb-bfe": "^3.6.0",
-    "ssb-box2": "^3.0.0",
+    "ssb-bfe": "^3.7.0",
+    "ssb-box2": "^3.0.1",
     "ssb-crut": "^4.6.1",
     "ssb-meta-feeds": "~0.30.0",
-    "ssb-private-group-keys": "^1.0.0"
+    "ssb-private-group-keys": "^1.0.0",
+    "ssb-uri2": "^2.4.0"
   },
   "devDependencies": {
     "c8": "^7.11.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "ssb-crut": "^4.6.1",
     "ssb-meta-feeds": "~0.30.0",
     "ssb-private-group-keys": "^1.0.0",
-    "ssb-ref": "^2.16.0",
     "ssb-uri2": "^2.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "pretty-quick": "^3.1.3",
     "secret-stack": "^6.4.1",
     "ssb-caps": "^1.1.0",
-    "ssb-db2": "ssbc/ssb-db2#uri-get",
+    "ssb-db2": "ssbc/ssb-db2#master",
     "ssb-ebt": "^9.1.2",
     "tap-arc": "^0.3.4",
     "tape": "^5.5.3"

--- a/test/add-member.test.js
+++ b/test/add-member.test.js
@@ -6,6 +6,7 @@ const test = require('tape')
 const pull = require('pull-stream')
 const { promisify: p } = require('util')
 const ssbKeys = require('ssb-keys')
+const { fromFeedSigil } = require('ssb-uri2')
 const Testbot = require('./helpers/testbot')
 const replicate = require('./helpers/replicate')
 
@@ -54,7 +55,10 @@ test('add member', async (t) => {
     const group = await kaitiaki.tribes2.create()
     t.true(group.id, 'creates group')
 
-    const authorIds = [newPerson.id, ssbKeys.generate().id]
+    const authorIds = [
+      fromFeedSigil(newPerson.id),
+      fromFeedSigil(ssbKeys.generate().id),
+    ]
 
     const encryptedInvite = await kaitiaki.tribes2.addMembers(
       group.id,

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -3,12 +3,11 @@
 // SPDX-License-Identifier: CC0-1.0
 
 const test = require('tape')
-const ref = require('ssb-ref')
+const { isClassicMessageSSBURI, isIdentityGroupSSBURI } = require('ssb-uri2')
 const { promisify: p } = require('util')
 const pull = require('pull-stream')
 const { author, descending, toPullStream, where } = require('ssb-db2/operators')
 const Testbot = require('./helpers/testbot')
-const replicate = require('./helpers/replicate')
 
 test('create', async (t) => {
   const ssb = Testbot()
@@ -17,9 +16,9 @@ test('create', async (t) => {
     .create()
     .catch(t.error)
 
-  t.true(ref.isCloakedMsgId(id), 'has id')
+  t.true(isIdentityGroupSSBURI(id), 'has group id')
   t.true(Buffer.isBuffer(secret), 'has secret')
-  t.true(ref.isMsg(root), 'has root')
+  t.true(isClassicMessageSSBURI(root), 'has root')
   //TODO
   //t.true(subfeed && ref.isFeed(subfeed.id), 'has subfeed')
 
@@ -51,7 +50,7 @@ test('create more', (t) => {
     t.error(err, 'no error')
 
     const { id, secret, root } = data
-    t.true(ref.isCloakedMsg(id), 'returns group identifier - groupId')
+    t.true(isIdentityGroupSSBURI(id), 'returns group identifier - groupId')
     t.true(
       Buffer.isBuffer(secret) && secret.length === 32,
       'returns group symmetric key - groupKey'

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: CC0-1.0
 
 const test = require('tape')
-const { isClassicMessageSSBURI, isIdentityGroupSSBURI } = require('ssb-uri2')
+const {
+  isClassicMessageSSBURI,
+  isIdentityGroupSSBURI,
+  fromFeedSigil,
+} = require('ssb-uri2')
 const { promisify: p } = require('util')
 const pull = require('pull-stream')
 const { author, descending, toPullStream, where } = require('ssb-db2/operators')
@@ -84,7 +88,7 @@ test('create more', (t) => {
               version: 'v1',
               groupKey: secret.toString('base64'),
               root: root,
-              recps: [id, server.id], // me being added to the group
+              recps: [id, fromFeedSigil(server.id)], // me being added to the group
               tangles: {
                 members: {
                   root: root,

--- a/test/helpers/replicate.js
+++ b/test/helpers/replicate.js
@@ -45,4 +45,5 @@ async function waitUntilMember(person, groupId) {
       .catch(() => {})
     await p(setTimeout)(100)
   }
+  if (!isMember) throw new Error("Didn't become a member in time")
 }

--- a/test/list-and-get.test.js
+++ b/test/list-and-get.test.js
@@ -5,7 +5,7 @@
 const test = require('tape')
 const { promisify: p } = require('util')
 const pull = require('pull-stream')
-const ref = require('ssb-ref')
+const { isClassicMessageSSBURI, isIdentityGroupSSBURI } = require('ssb-uri2')
 const Testbot = require('./helpers/testbot')
 
 test('tribes.list + tribes.get', (t) => {
@@ -94,11 +94,11 @@ test('get', async (t) => {
 
   //- `subfeed` *Keys* - the keys of the subfeed you should publish group data to
   t.equal(id, group.id)
-  t.true(ref.isCloakedMsg(group.id))
+  t.true(isIdentityGroupSSBURI(group.id))
   //TODO: subfeed
   t.true(Buffer.isBuffer(group.secret))
   t.equal(secret, group.secret)
-  t.true(ref.isMsg(group.root), 'has root')
+  t.true(isClassicMessageSSBURI(group.root), 'has root')
   t.equal(root, group.root)
 
   await p(ssb.close)(true)
@@ -110,7 +110,7 @@ test('list', (t) => {
   ssb.tribes2
     .create()
     .then(({ id: id1, secret: secret1 }) => {
-      t.true(ref.isCloakedMsgId(id1), 'has id')
+      t.true(isIdentityGroupSSBURI(id1), 'has id')
 
       pull(
         ssb.tribes2.list(),

--- a/test/list-members.test.js
+++ b/test/list-members.test.js
@@ -6,6 +6,7 @@ const test = require('tape')
 const keys = require('ssb-keys')
 const Testbot = require('./helpers/testbot')
 const pull = require('pull-stream')
+const uri = require('ssb-uri2')
 
 test('list members', (t) => {
   const server = Testbot()
@@ -14,7 +15,7 @@ test('list members', (t) => {
     t.error(err, 'created group')
     const newFriends = Array(6)
       .fill(0)
-      .map(() => keys.generate().id)
+      .map(() => uri.fromFeedSigil(keys.generate().id))
 
     server.tribes2.addMembers(group.id, newFriends, { text: 'ahoy' }, (err) => {
       t.error(err, 'invited friends')
@@ -24,7 +25,11 @@ test('list members', (t) => {
         pull.collect((err, authors) => {
           t.error(err, 'returned members')
 
-          t.deepEqual(authors, [server.id, ...newFriends], 'lists members')
+          t.deepEqual(
+            authors,
+            [uri.fromFeedSigil(server.id), ...newFriends],
+            'lists members'
+          )
 
           server.close(true, t.end)
         })


### PR DESCRIPTION
Fixes https://github.com/ssbc/ssb-tribes2/issues/13

* [x] Maybe do https://github.com/ssbc/ssb-uri2/issues/18 before merging to make the code here cleaner
  * [x] If we do the above then uninstall ssb-ref again
* [x] Should we update `buildGroupId` to not calculate on sigil keys? I guess? no. see comment below
  * [x] We might need to update the envelope spec? Depends on how `encode` works i guess? What's SLP? https://github.com/ssbc/envelope-spec/tree/master/cloaked_msg_id