### PR TITLE
Fix reindex so it waits for the group key to be added to keyring

### DIFF
--- a/index.js
+++ b/index.js
@@ -379,12 +379,17 @@ module.exports = {
         pull.drain(
           (groupInfo) => {
             foundInvite = true
-            ssb.box2.addGroupInfo(groupInfo.id, {
-              key: groupInfo.secret,
-              root: groupInfo.root,
-            })
-
-            ssb.db.reindexEncrypted(cb)
+            ssb.box2.addGroupInfo(
+              groupInfo.id,
+              {
+                key: groupInfo.secret,
+                root: groupInfo.root,
+              },
+              (err) => {
+                if (err) cb(err)
+                else ssb.db.reindexEncrypted(cb)
+              }
+            )
           },
           (err) => {
             if (err) return cb(err)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ssb-box2": "^4.0.0",
     "ssb-crut": "^4.6.1",
     "ssb-db2": "^6.3.0",
-    "ssb-meta-feeds": "^0.38.2",
+    "ssb-meta-feeds": "0.38.1",
     "ssb-private-group-keys": "^1.1.1",
     "ssb-ref": "^2.16.0",
     "ssb-uri2": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ssb-box2": "^4.0.0",
     "ssb-crut": "^4.6.1",
     "ssb-db2": "^6.3.0",
-    "ssb-meta-feeds": "0.38.1",
+    "ssb-meta-feeds": "^0.38.2",
     "ssb-private-group-keys": "^1.1.1",
     "ssb-ref": "^2.16.0",
     "ssb-uri2": "^2.4.1"


### PR DESCRIPTION
This uses the updated box2 addGroupInfo to fix a concurrency bug. This also unpins meta-feeds because I believe that should be fixed with https://github.com/ssbc/jitdb/pull/240. So tests might not work right now until that is merged.