### PR TITLE
split out meta feed shuffling into helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const AddGroupTangle = require('./lib/add-group-tangle')
 const MetaFeedHelpers = require('./lib/meta-feed-helpers')
 const buildGroupId = require('./lib/build-group-id')
 const publishAndPrune = require('./lib/prune-publish')
+const drainOne = require('./lib/drain-one')
 
 module.exports = {
   name: 'tribes2',
@@ -312,8 +313,4 @@ module.exports = {
       start,
     }
   },
-}
-
-function drainOne(handleErr, handleRes) {
-  return pull(pull.take(1), pull.drain(handleErr, handleRes))
 }

--- a/index.js
+++ b/index.js
@@ -10,24 +10,16 @@ const clarify = require('clarify-error')
 const {
   where,
   and,
-  count,
   isDecrypted,
   type,
   live,
-  author,
-  toCallback,
   toPullStream,
 } = require('ssb-db2/operators')
-const {
-  keySchemes,
-  validator: {
-    group: { init: initSpec, addMember: addMemberSpec },
-  },
-} = require('private-group-spec')
-const { SecretKey } = require('ssb-private-group-keys')
 const { fromMessageSigil, isBendyButtV1FeedSSBURI } = require('ssb-uri2')
-const buildGroupId = require('./lib/build-group-id')
+
 const AddGroupTangle = require('./lib/add-group-tangle')
+const MetaFeedHelpers = require('./lib/meta-feed-helpers')
+const buildGroupId = require('./lib/build-group-id')
 const publishAndPrune = require('./lib/prune-publish')
 
 module.exports = {
@@ -42,217 +34,13 @@ module.exports = {
   // eslint-disable-next-line no-unused-vars
   init(ssb, config) {
     const addGroupTangle = AddGroupTangle(ssb)
+    const {
+      secretKeyFromPurpose,
 
-    function findOrCreateAdditionsFeed(cb) {
-      const details = {
-        purpose: 'group/additions',
-        feedFormat: 'classic',
-      }
-
-      ssb.metafeeds.findOrCreate(details, cb)
-    }
-
-    function findEmptyGroupFeed(rootId, cb) {
-      let found = false
-      pull(
-        ssb.metafeeds.branchStream({ root: rootId, old: true, live: false }),
-        pull.filter((branch) => branch.length === 4),
-        pull.map((branch) => branch[3]),
-        // only grab feeds that look like group feeds
-        pull.filter((feed) => feed.recps && feed.purpose.length === 44),
-        paraMap((feed, cb) => {
-          ssb.db.query(
-            where(author(feed.id)),
-            count(),
-            toCallback((err, count) => {
-              // prettier-ignore
-              if (err) return cb(clarify(err, 'Failed to count messages in group feed'))
-
-              if (count === 0) {
-                // we're only interested in empty feeds
-                return cb(null, feed)
-              } else {
-                return cb()
-              }
-            })
-          )
-        }),
-        pull.filter(),
-        pull.unique('id'),
-        pull.take(1),
-        pull.drain(
-          (emptyFeed) => {
-            found = true
-            return cb(null, emptyFeed)
-          },
-          (err) => {
-            if (err) cb(clarify(err, 'Failed to find empty group feed'))
-            if (!found) cb()
-          }
-        )
-      )
-    }
-
-    function findOrCreateFromSecret(secret, rootId, cb) {
-      const recps = [
-        { key: secret.toBuffer(), scheme: keySchemes.private_group },
-        // encrypt to myself to be able to get back to the group without finding the group/add-member for me (maybe i crashed before adding myself)
-        rootId,
-      ]
-
-      const groupFeedDetails = {
-        purpose: secret.toString(),
-        feedFormat: 'classic',
-        recps,
-        encryptionFormat: 'box2',
-      }
-
-      ssb.metafeeds.findOrCreate(groupFeedDetails, (err, groupFeed) => {
-        if (err) return cb(clarify(err, 'Failed to find or create group feed'))
-        cb(null, groupFeed)
-      })
-    }
-
-    function findOrCreateGroupFeed(input = null, cb) {
-      const inputSecret = Buffer.isBuffer(input) ? new SecretKey(input) : input
-
-      ssb.metafeeds.findOrCreate(function gotRoot(err, root) {
-        // prettier-ignore
-        if (err) return cb(clarify(err, 'Failed to find or create root feed when finding or creating group feed'))
-
-        // 1. publish. we know the secret and should just findOrCreate the feed
-        // 2. create. we don't have a secret yet but can make or find one
-        //   2.1. try to find an empty feed in case we've crashed before. use the secret from that one
-        //   2.2. if we can't find an empty feed, make a new secret and findOrCreate
-
-        if (inputSecret) {
-          return findOrCreateFromSecret(inputSecret, root.id, cb)
-        } else {
-          findEmptyGroupFeed(root.id, (err, emptyFeed) => {
-            // prettier-ignore
-            if (err) return cb(clarify(err, 'Failed to find empty group feed when finding or creating a group'))
-
-            if (emptyFeed) {
-              return cb(null, emptyFeed)
-            } else {
-              const newSecret = new SecretKey()
-              findOrCreateFromSecret(newSecret, root.id, cb)
-            }
-          })
-        }
-      })
-    }
-
-    function secretKeyFromPurpose(purpose) {
-      return new SecretKey(Buffer.from(purpose, 'base64'))
-    }
-
-    function createGroupWithoutMembers(myRoot, cb) {
-      const content = {
-        type: 'group/init',
-        tangles: {
-          group: { root: null, previous: null },
-        },
-      }
-      if (!initSpec(content)) return cb(new Error(initSpec.errorsString))
-
-      findOrCreateGroupFeed(null, function gotGroupFeed(err, groupFeed) {
-        // prettier-ignore
-        if (err) return cb(clarify(err, 'Failed to find or create group feed when creating a group'))
-
-        const secret = secretKeyFromPurpose(groupFeed.purpose)
-
-        const recps = [
-          { key: secret.toBuffer(), scheme: keySchemes.private_group },
-          myRoot.id,
-        ]
-
-        ssb.db.create(
-          {
-            keys: groupFeed.keys,
-            content,
-            recps,
-            encryptionFormat: 'box2',
-          },
-          (err, groupInitMsg) => {
-            // prettier-ignore
-            if (err) return cb(clarify(err, "couldn't create group root message"))
-            return cb(null, { groupInitMsg, groupFeed, myRoot })
-          }
-        )
-      })
-    }
-
-    /** more specifically: a group that has never had any members. i.e. either
-     * 1. newly created but tribes2 crashed before we had time to add ourselves to it. in that case find and return it. if we can't find such a group then
-     * 2. freshly create a new group, and return */
-    function findOrCreateGroupWithoutMembers(cb) {
-      ssb.metafeeds.findOrCreate(function gotRoot(err, myRoot) {
-        // prettier-ignore
-        if (err) return cb(clarify(err, 'Failed to find or create root feed when creating a group'))
-
-        // find groups without any group/add-member messages
-        let foundMemberlessGroup = false
-        pull(
-          ssb.db.query(
-            where(and(isDecrypted('box2'), type('group/init'))),
-            toPullStream()
-          ),
-          pull.asyncMap((rootMsg, cb) => {
-            let foundMember = false
-            pull(
-              ssb.db.query(
-                where(and(isDecrypted('box2'), type('group/add-member'))),
-                toPullStream()
-              ),
-              pull.filter(
-                (msg) =>
-                  msg?.value?.content?.root === fromMessageSigil(rootMsg.key)
-              ),
-              pull.take(1),
-              pull.drain(
-                () => {
-                  foundMember = true
-                  return cb(null, false)
-                },
-                (err) => {
-                  if (err) return cb(err)
-                  else if (!foundMember) cb(null, rootMsg)
-                }
-              )
-            )
-          }),
-          pull.filter(Boolean),
-          pull.take(1),
-          pull.drain(
-            (rootMsg) => {
-              foundMemberlessGroup = true
-              ssb.metafeeds.advanced.findById(
-                rootMsg.value.author,
-                (err, groupFeed) => {
-                  // prettier-ignore
-                  if (err) return cb(clarify(err, "failed finding details of the memberless group feed"))
-
-                  rootMsg.value.content = rootMsg.meta.originalContent
-                  return cb(null, {
-                    groupInitMsg: rootMsg,
-                    groupFeed,
-                    myRoot,
-                  })
-                }
-              )
-            },
-            (err) => {
-              // prettier-ignore
-              if (err) return cb(clarify(err, "errored trying to find potential memberless feed"))
-              else if (!foundMemberlessGroup) {
-                return createGroupWithoutMembers(myRoot, cb)
-              }
-            }
-          )
-        )
-      })
-    }
+      findOrCreateAdditionsFeed,
+      findOrCreateGroupFeed,
+      findOrCreateGroupWithoutMembers,
+    } = MetaFeedHelpers(ssb)
 
     function create(opts = {}, cb) {
       if (cb === undefined) return promisify(create)(opts)
@@ -472,8 +260,7 @@ module.exports = {
       pull(
         listInvites(),
         pull.filter((groupInfo) => groupInfo.id === groupId),
-        pull.take(1),
-        pull.drain(
+        drainOne(
           (groupInfo) => {
             foundInvite = true
             ssb.box2.addGroupInfo(
@@ -525,4 +312,8 @@ module.exports = {
       start,
     }
   },
+}
+
+function drainOne(handleErr, handleRes) {
+  return pull(pull.take(1), pull.drain(handleErr, handleRes))
 }

--- a/lib/drain-one.js
+++ b/lib/drain-one.js
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2022 Mix Irving
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
+const pull = require('pull-stream')
+
+module.exports = function drainOne (handleRes, handleDone) {
+  return pull(
+    pull.take(1),
+    pull.drain(
+      handleRes,
+      handleDone
+    )
+  )
+}

--- a/lib/meta-feed-helpers.js
+++ b/lib/meta-feed-helpers.js
@@ -1,0 +1,242 @@
+const { SecretKey } = require('ssb-private-group-keys')
+const {
+  where,
+  and,
+  count,
+  isDecrypted,
+  type,
+  author,
+  toCallback,
+  toPullStream,
+} = require('ssb-db2/operators')
+const { fromMessageSigil } = require('ssb-uri2')
+const {
+  keySchemes,
+  validator: {
+    group: { init: initSpec },
+  },
+} = require('private-group-spec')
+const pull = require('pull-stream')
+const paraMap = require('pull-paramap')
+const clarify = require('clarify-error')
+
+function secretKeyFromPurpose(purpose) {
+  return new SecretKey(Buffer.from(purpose, 'base64'))
+}
+
+module.exports = (ssb) => {
+  function findOrCreateAdditionsFeed(cb) {
+    const details = {
+      purpose: 'group/additions',
+      feedFormat: 'classic',
+    }
+
+    ssb.metafeeds.findOrCreate(details, cb)
+  }
+
+  function findEmptyGroupFeed(rootId, cb) {
+    let found = false
+    pull(
+      ssb.metafeeds.branchStream({ root: rootId, old: true, live: false }),
+      pull.filter((branch) => branch.length === 4),
+      pull.map((branch) => branch[3]),
+      // only grab feeds that look like group feeds
+      pull.filter((feed) => feed.recps && feed.purpose.length === 44),
+      paraMap((feed, cb) => {
+        ssb.db.query(
+          where(author(feed.id)),
+          count(),
+          toCallback((err, count) => {
+            // prettier-ignore
+            if (err) return cb(clarify(err, 'Failed to count messages in group feed'))
+
+            if (count === 0) {
+              // we're only interested in empty feeds
+              return cb(null, feed)
+            } else {
+              return cb()
+            }
+          })
+        )
+      }, 4),
+      pull.filter(Boolean),
+      drainOne(
+        (emptyFeed) => {
+          found = true
+          return cb(null, emptyFeed)
+        },
+        (err) => {
+          if (err) cb(clarify(err, 'Failed to find empty group feed'))
+          if (!found) cb()
+        }
+      )
+    )
+  }
+
+  function findOrCreateFromSecret(secret, rootId, cb) {
+    const recps = [
+      { key: secret.toBuffer(), scheme: keySchemes.private_group },
+      // encrypt to myself to be able to get back to the group without finding the group/add-member for me (maybe i crashed before adding myself)
+      rootId,
+    ]
+
+    const groupFeedDetails = {
+      purpose: secret.toString(),
+      feedFormat: 'classic',
+      recps,
+      encryptionFormat: 'box2',
+    }
+
+    ssb.metafeeds.findOrCreate(groupFeedDetails, (err, groupFeed) => {
+      if (err) return cb(clarify(err, 'Failed to find or create group feed'))
+      cb(null, groupFeed)
+    })
+  }
+
+  function findOrCreateGroupFeed(input = null, cb) {
+    const inputSecret = Buffer.isBuffer(input) ? new SecretKey(input) : input
+
+    ssb.metafeeds.findOrCreate(function gotRoot(err, root) {
+      // prettier-ignore
+      if (err) return cb(clarify(err, 'Failed to find or create root feed when finding or creating group feed'))
+
+      // 1. publish. we know the secret and should just findOrCreate the feed
+      // 2. create. we don't have a secret yet but can make or find one
+      //   2.1. try to find an empty feed in case we've crashed before. use the secret from that one
+      //   2.2. if we can't find an empty feed, make a new secret and findOrCreate
+
+      if (inputSecret) {
+        return findOrCreateFromSecret(inputSecret, root.id, cb)
+      } else {
+        findEmptyGroupFeed(root.id, (err, emptyFeed) => {
+          // prettier-ignore
+          if (err) return cb(clarify(err, 'Failed to find empty group feed when finding or creating a group'))
+
+          if (emptyFeed) {
+            return cb(null, emptyFeed)
+          } else {
+            const newSecret = new SecretKey()
+            findOrCreateFromSecret(newSecret, root.id, cb)
+          }
+        })
+      }
+    })
+  }
+
+  function createGroupWithoutMembers(myRoot, cb) {
+    const content = {
+      type: 'group/init',
+      tangles: {
+        group: { root: null, previous: null },
+      },
+    }
+    if (!initSpec(content)) return cb(new Error(initSpec.errorsString))
+
+    findOrCreateGroupFeed(null, function gotGroupFeed(err, groupFeed) {
+      // prettier-ignore
+      if (err) return cb(clarify(err, 'Failed to find or create group feed when creating a group'))
+
+      const secret = secretKeyFromPurpose(groupFeed.purpose)
+
+      const recps = [
+        { key: secret.toBuffer(), scheme: keySchemes.private_group },
+        myRoot.id,
+      ]
+
+      ssb.db.create(
+        {
+          keys: groupFeed.keys,
+          content,
+          recps,
+          encryptionFormat: 'box2',
+        },
+        (err, groupInitMsg) => {
+          // prettier-ignore
+          if (err) return cb(clarify(err, "couldn't create group root message"))
+          return cb(null, { groupInitMsg, groupFeed, myRoot })
+        }
+      )
+    })
+  }
+
+  /** more specifically: a group that has never had any members. i.e. either
+   * 1. newly created but tribes2 crashed before we had time to add ourselves to it. in that case find and return it. if we can't find such a group then
+   * 2. freshly create a new group, and return */
+  function findOrCreateGroupWithoutMembers(cb) {
+    ssb.metafeeds.findOrCreate(function gotRoot(err, myRoot) {
+      // prettier-ignore
+      if (err) return cb(clarify(err, 'Failed to find or create root feed when creating a group'))
+
+      // find groups without any group/add-member messages
+      let foundMemberlessGroup = false
+      pull(
+        ssb.db.query(
+          where(and(isDecrypted('box2'), type('group/init'))),
+          toPullStream()
+        ),
+        pull.asyncMap((rootMsg, cb) => {
+          let foundMember = false
+          pull(
+            ssb.db.query(
+              where(and(isDecrypted('box2'), type('group/add-member'))),
+              toPullStream()
+            ),
+            pull.filter(
+              (msg) =>
+                msg?.value?.content?.root === fromMessageSigil(rootMsg.key)
+            ),
+            drainOne(
+              () => {
+                foundMember = true
+                return cb(null, false)
+              },
+              (err) => {
+                if (err) return cb(err)
+                else if (!foundMember) cb(null, rootMsg)
+              }
+            )
+          )
+        }),
+        pull.filter(Boolean),
+        drainOne(
+          (rootMsg) => {
+            foundMemberlessGroup = true
+            ssb.metafeeds.advanced.findById(
+              rootMsg.value.author,
+              (err, groupFeed) => {
+                // prettier-ignore
+                if (err) return cb(clarify(err, "failed finding details of the memberless group feed"))
+
+                rootMsg.value.content = rootMsg.meta.originalContent
+                return cb(null, {
+                  groupInitMsg: rootMsg,
+                  groupFeed,
+                  myRoot,
+                })
+              }
+            )
+          },
+          (err) => {
+            // prettier-ignore
+            if (err) return cb(clarify(err, "errored trying to find potential memberless feed"))
+            else if (!foundMemberlessGroup) {
+              return createGroupWithoutMembers(myRoot, cb)
+            }
+          }
+        )
+      )
+    })
+  }
+
+  return {
+    secretKeyFromPurpose,
+
+    findOrCreateAdditionsFeed,
+    findOrCreateGroupFeed,
+    findOrCreateGroupWithoutMembers
+  }
+}
+
+function drainOne(handleErr, handleRes) {
+  return pull(pull.take(1), pull.drain(handleErr, handleRes))
+}

--- a/lib/meta-feed-helpers.js
+++ b/lib/meta-feed-helpers.js
@@ -24,6 +24,8 @@ const pull = require('pull-stream')
 const paraMap = require('pull-paramap')
 const clarify = require('clarify-error')
 
+const drainOne = require('./drain-one')
+
 function secretKeyFromPurpose(purpose) {
   return new SecretKey(Buffer.from(purpose, 'base64'))
 }
@@ -239,8 +241,4 @@ module.exports = (ssb) => {
     findOrCreateGroupFeed,
     findOrCreateGroupWithoutMembers
   }
-}
-
-function drainOne(handleErr, handleRes) {
-  return pull(pull.take(1), pull.drain(handleErr, handleRes))
 }

--- a/lib/meta-feed-helpers.js
+++ b/lib/meta-feed-helpers.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Jacob Karlsson
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
 const { SecretKey } = require('ssb-private-group-keys')
 const {
   where,

--- a/lib/prune-publish.js
+++ b/lib/prune-publish.js
@@ -4,7 +4,6 @@
 
 const clarify = require('clarify-error')
 
-
 module.exports = function prunePublish(ssb, content, keys, cb) {
   const group = content.tangles.group
 
@@ -16,9 +15,6 @@ module.exports = function prunePublish(ssb, content, keys, cb) {
 
         return prunePublish(ssb, content, keys, cb)
       } else {
-        console.log(content)
-        console.log(keys)
-        console.log(err)
         return cb(clarify(err, 'Failed to publish message in prunePublish'))
       }
     }

--- a/lib/prune-publish.js
+++ b/lib/prune-publish.js
@@ -16,6 +16,9 @@ module.exports = function prunePublish(ssb, content, keys, cb) {
 
         return prunePublish(ssb, content, keys, cb)
       } else {
+        console.log(content)
+        console.log(keys)
+        console.log(err)
         return cb(clarify(err, 'Failed to publish message in prunePublish'))
       }
     }


### PR DESCRIPTION
Was reading over code, and found the index.js file overwhelming. Split out functions that were meta-feed related into a single file, so the API parts of the code were clearer/ easier to find.

I also added a function `drainOne` because the "take + drain" pattern looks dangerous to me - if someone changes that `take(1)` at any point then you are gonna get multiple calls of `cb`, which would create weird / bad bugs