### PR TITLE
Unpin ssb-meta-feeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ssb-box2": "^5.0.0",
     "ssb-crut": "^4.6.1",
     "ssb-db2": "^6.3.0",
-    "ssb-meta-feeds": "0.38.1",
+    "ssb-meta-feeds": "^0.38.2",
     "ssb-private-group-keys": "^1.1.1",
     "ssb-ref": "^2.16.0",
     "ssb-uri2": "^2.4.1"

--- a/test/helpers/replicate.js
+++ b/test/helpers/replicate.js
@@ -21,6 +21,14 @@ module.exports = async function replicate(person1, person2) {
     pull.flatten(),
     pull.map((feedDetails) => feedDetails.id),
     pull.unique(),
+    pull.asyncMap((feedId, cb) => {
+      // hack to make it look like we request feeds in the right order
+      // instead of just one big pile, ssb-meta-feeds operates under
+      // the assumption that we get messages in proper order
+      setTimeout(() => {
+        cb(null, feedId)
+      }, 200)
+    }, 1),
     (drain = pull.drain((feedId) => {
       person1.ebt.request(feedId, true)
       person2.ebt.request(feedId, true)


### PR DESCRIPTION
... and add workaround in replicate to better simulate real EBT.

This should now work. A bit hacky. Might need https://github.com/ssbc/ssb-meta-feeds/pull/118 to work. This is working locally with that patch.

Should fix #48 