### PR TITLE
speed up request step for replicate

### DIFF
--- a/test/helpers/replicate.js
+++ b/test/helpers/replicate.js
@@ -11,7 +11,39 @@ const deepEqual = require('fast-deep-equal')
  * Fully replicates person1's metafeed tree to person2 and vice versa
  */
 module.exports = async function replicate(person1, person2) {
-  // persons replicate all the trees in their forests, from top to bottom
+  // Establish a network connection
+  const conn = await p(person1.connect)(person2.getAddress())
+
+  // ensure persons are replicating all the trees in their forests,
+  // from top to bottom
+  const drain = await setupFeedRequests(person1, person2)
+
+  // Wait until both have replicated all feeds in full (are in sync)
+  await retryUntil(async () => {
+    const clocks = await Promise.all([
+      p(person1.getVectorClock)(),
+      p(person2.getVectorClock)()
+    ])
+    return deepEqual(...clocks)
+  })
+
+  if (drain) drain.abort()
+  await p(conn.close)(true)
+}
+
+async function setupFeedRequests (person1, person2) {
+  // check if each person has same feeds mentioned in clocks
+  // (we assume this means ebt.request have been called on them)
+
+  const [clock1, clock2] = await Promise.all([
+    p(person1.getVectorClock)(),
+    p(person2.getVectorClock)()
+  ])
+
+  if (isSameKeys(clock1, clock2)) return
+
+  // if clocks don't have same keys, then request them both to be
+  // replicating the same feeds from meta-feed trees
   let drain
   pull(
     pullMany([
@@ -22,40 +54,44 @@ module.exports = async function replicate(person1, person2) {
     pull.map((feedDetails) => feedDetails.id),
     pull.unique(),
     pull.asyncMap((feedId, cb) => {
+      // skip re-requesting if not needed
+      if (feedId in clock1 && feedId in clock2) return cb(null, null)
+
       // hack to make it look like we request feeds in the right order
       // instead of just one big pile, ssb-meta-feeds operates under
       // the assumption that we get messages in proper order
-      setTimeout(() => {
-        cb(null, feedId)
-      }, 200)
-    }, 1),
+      setTimeout(() => cb(null, feedId), 200)
+    }),
+    pull.filter(Boolean), // filter out "null" entries
     (drain = pull.drain((feedId) => {
       person1.ebt.request(feedId, true)
       person2.ebt.request(feedId, true)
     }))
   )
 
-  // Establish a network connection
-  const conn = await p(person1.connect)(person2.getAddress())
-
-  // Wait until both have replicated all feeds in full
-  await retryUntil(async () => {
-    const newClock1 = await p(person1.getVectorClock)()
-    const newClock2 = await p(person2.getVectorClock)()
-    return deepEqual(newClock1, newClock2)
-  })
-
-  drain.abort()
-
-  await p(conn.close)(true)
+  return drain
 }
 
-async function retryUntil(fn) {
-  let result = false
+async function retryUntil(checkIsDone) {
+  let isDone = false
   for (let i = 0; i < 100; i++) {
-    result = await fn()
-    if (result) return
-    else await p(setTimeout)(100)
+    isDone = await checkIsDone()
+    if (isDone) return
+
+    await p(setTimeout)(100)
   }
-  if (!result) throw new Error('retryUntil timed out')
+  if (!isDone) throw new Error('retryUntil timed out')
+}
+
+function isSameKeys (objA, objB) {
+  return isSameSet(
+    new Set(Object.keys(objA)),
+    new Set(Object.keys(objB))
+  )
+}
+function isSameSet(A, B) {
+  return (
+    A.size === B.size &&
+    [...A].every(x => B.has(x))
+  )
 }


### PR DESCRIPTION
This PR modifies replicate helper in tests to remove redundent 200ms waits (and redundent streaming of meta feeds if not needed)

Test suite times on my desktop:

BEFORE:  264.968 s
AFTER:   252.572 s

FML