### PR TITLE
Epoch check missing members

### DIFF
--- a/lib/epochs.js
+++ b/lib/epochs.js
@@ -31,6 +31,13 @@ function toPattern (regexp) {
   return regexp.toString().replace(/^\//, '').replace(/\/$/, '')
 }
 
+// This strategy describes how to "reduce" the tangle of epochs and their data.
+// Here OverwriteFieleds lets any link in the tangle contain Objects with form
+// { [key]: value } so long as
+//   - key matches msgPattern,
+//   - value is { author, epochKey }
+//
+// Since each key is unique here this behaves like Object.assign (with checks)
 const strategy = OverwriteFields({
   keyPattern: msgPattern,
   valueSchema: {
@@ -47,23 +54,34 @@ const strategy = OverwriteFields({
     }
   }
 })
-strategy.mapToPure = T => T || strategy.identity() // function @tangle/reduce needs
+// PATCH: @tangle/reduce needs this
+strategy.mapToPure = T => T || strategy.identity()
 
 module.exports = function Epochs (ssb) {
   function getEpochs (groupId, cb) {
     if (cb === undefined) return p(getEpochs)(groupId)
 
-    reduceEpochs(ssb, groupId, (err, reduce) => {
+    const getters = {
+      author (msg, cb) {
+        ssb.metafeeds.findRootFeedId(msg.value.author, cb)
+      },
+      epochKey (msg, cb) {
+        cb(null, msg.value.content.groupKey)
+      }
+    }
+
+    reduceEpochs(ssb, groupId, getters, (err, reduce) => {
       if (err) return cb(clarify(err, 'Failed to resolve epoch @tangle/reduce'))
 
       const epochs = reduce.graph.connectedNodes
         .map(node => {
-          return {
-            id: node.key,
+          const info = {
+            id: node.key, // alias: epochRoot
             previous: node.previous,
-            author: node.data[node.key].author,
-            epochKey: Buffer.from(node.data[node.key].epochKey, 'base64')
+            ...node.data[node.key]
           }
+          info.epochKey = Buffer.from(info.epochKey, 'base64')
+          return info
         })
 
       cb(null, epochs)
@@ -82,7 +100,11 @@ module.exports = function Epochs (ssb) {
   }
 }
 
-function reduceEpochs (ssb, groupId, cb) {
+function reduceEpochs (ssb, groupId, getters = {}, cb) {
+  // getters is an Object of form:
+  // {
+  //   [fieldName]: fieldGetter(msg, cb)
+  // }
   ssb.box2.getGroupInfo(groupId, (err, info) => {
     if (err) return cb(clarify(err, 'Failed to get group info for ' + groupId))
 
@@ -101,21 +123,32 @@ function reduceEpochs (ssb, groupId, cb) {
             ...updates.filter(isInitEpoch)
           ]),
           pull.asyncMap((msg, cb) => {
-            ssb.metafeeds.findRootFeedId(msg.value.author, (err, feedId) => {
-              if (err) return cb(clarify(err, 'Failed find root feed id of ' + msg.value.author))
+            const epochRoot = toMsgURI(msg.key)
+            const epochData = {}
 
-              const key = toMsgURI(msg.key)
-              cb(null, {
-                key,
-                previous: msg.value.content.tangles.epoch.previous,
-                data: {
-                  [key]: {
-                    author: feedId,
-                    epochKey: msg.value.content.groupKey
+            // go through all the getters, get their info, and attach it to epochData
+            pull(
+              pull.keys(getters),
+              pull.asyncMap((fieldName, cb) => {
+                const getter = getters[fieldName]
+                getter(msg, (err, fieldData) => {
+                  if (err) return cb(clarify(err, 'Failed to get epoch ' + fieldName))
+                  epochData[fieldName] = fieldData
+                  cb(null)
+                })
+              }),
+              pull.collect((err) => {
+                if (err) return cb(clarify(err, 'Failed to collect epoch data'))
+
+                cb(null, {
+                  key: epochRoot,
+                  previous: msg.value.content.tangles.epoch.previous,
+                  data: {
+                    [epochRoot]: epochData
                   }
-                }
+                })
               })
-            })
+            )
           }),
           pull.collect((err, nodes) => {
             if (err) return cb(clarify(err, 'Failure collecting epoch messages'))

--- a/lib/epochs.js
+++ b/lib/epochs.js
@@ -32,7 +32,7 @@ const secretPattern = toPattern(isCanonicalBase64(null, null, 32))
 // Here OverwriteFieleds lets any link in the tangle contain Objects with form
 // { [key]: value } so long as
 //   - key matches msgPattern,
-//   - value is { author, epochKey }
+//   - value is { author, secret }
 //
 // Since each key is unique here this behaves like Object.assign (with checks)
 const strategy = OverwriteFields({
@@ -44,7 +44,7 @@ const strategy = OverwriteFields({
         type: 'string',
         pattern: feedPattern
       },
-      epochKey: {
+      secret: {
         type: 'string',
         pattern: secretPattern
       },
@@ -58,7 +58,7 @@ const strategy = OverwriteFields({
         additionalProperties: false
       }
     },
-    required: ['author', 'epochKey'],
+    required: ['author', 'secret'],
     additionalProperties: false
   }
 })
@@ -70,7 +70,7 @@ module.exports = function Epochs (ssb) {
     author (epochRoot, cb) {
       ssb.metafeeds.findRootFeedId(epochRoot.value.author, cb)
     },
-    epochKey (epochRoot, cb) {
+    secret (epochRoot, cb) {
       cb(null, epochRoot.value.content.groupKey)
     },
     members (epochRoot, cb) {
@@ -82,7 +82,7 @@ module.exports = function Epochs (ssb) {
     getEpochs (groupId, cb) {
       if (cb === undefined) return p(this.getEpochs)(groupId)
 
-      const getters = pluck(allGetters, ['author', 'epochKey'])
+      const getters = pluck(allGetters, ['author', 'secret'])
       reduceEpochs(ssb, groupId, getters, (err, reduce) => {
         if (err) return cb(clarify(err, 'Failed to resolve epoch @tangle/reduce'))
 
@@ -93,7 +93,7 @@ module.exports = function Epochs (ssb) {
               previous: node.previous,
               ...node.data[node.key]
             }
-            info.epochKey = Buffer.from(info.epochKey, 'base64')
+            info.secret = Buffer.from(info.secret, 'base64')
             return info
           })
 
@@ -143,7 +143,7 @@ module.exports = function Epochs (ssb) {
           // If find some missing, record this epoch and missing members
           acc.push({
             epoch: node.key, // alias: epochRootId
-            epochKey: Buffer.from(node.data[node.key].epochKey, 'base64'),
+            secret: Buffer.from(node.data[node.key].secret, 'base64'),
             missing: [...difference(shouldBePresent, currentMembers)]
           })
           return acc

--- a/lib/epochs.js
+++ b/lib/epochs.js
@@ -20,16 +20,13 @@ const {
     }
   }
 } = require('private-group-spec')
+const difference = require('set.prototype.difference')
 
 const getTangleUpdates = require('./tangles/get-tangle-updates')
 
 const msgPattern = toPattern(new Butt64('ssb:message/[a-zA-Z0-9-]+/', null, 32))
 const feedPattern = toPattern(new Butt64('ssb:feed/[a-zA-Z0-9-]+/', null, 32))
 const secretPattern = toPattern(isCanonicalBase64(null, null, 32))
-
-function toPattern (regexp) {
-  return regexp.toString().replace(/^\//, '').replace(/\/$/, '')
-}
 
 // This strategy describes how to "reduce" the tangle of epochs and their data.
 // Here OverwriteFieleds lets any link in the tangle contain Objects with form
@@ -42,95 +39,168 @@ const strategy = OverwriteFields({
   keyPattern: msgPattern,
   valueSchema: {
     type: 'object',
-    properties: ['author', 'epochKey'],
-    required: ['author', 'epochKey'],
-    author: {
-      type: 'string',
-      pattern: feedPattern
+    properties: {
+      author: {
+        type: 'string',
+        pattern: feedPattern
+      },
+      epochKey: {
+        type: 'string',
+        pattern: secretPattern
+      },
+      members: {
+        type: 'object',
+        properties: {
+          added: { type: 'array' },
+          toExclude: { type: 'array' }
+        },
+        required: ['added', 'toExclude'],
+        additionalProperties: false
+      }
     },
-    epochKey: {
-      type: 'string',
-      pattern: secretPattern
-    }
+    required: ['author', 'epochKey'],
+    additionalProperties: false
   }
 })
 // PATCH: @tangle/reduce needs this
 strategy.mapToPure = T => T || strategy.identity()
 
 module.exports = function Epochs (ssb) {
-  function getEpochs (groupId, cb) {
-    if (cb === undefined) return p(getEpochs)(groupId)
-
-    const getters = {
-      author (msg, cb) {
-        ssb.metafeeds.findRootFeedId(msg.value.author, cb)
-      },
-      epochKey (msg, cb) {
-        cb(null, msg.value.content.groupKey)
-      }
+  const allGetters = {
+    author (epochRoot, cb) {
+      ssb.metafeeds.findRootFeedId(epochRoot.value.author, cb)
+    },
+    epochKey (epochRoot, cb) {
+      cb(null, epochRoot.value.content.groupKey)
+    },
+    members (epochRoot, cb) {
+      getMembers(ssb, epochRoot.key, cb)
     }
-
-    reduceEpochs(ssb, groupId, getters, (err, reduce) => {
-      if (err) return cb(clarify(err, 'Failed to resolve epoch @tangle/reduce'))
-
-      const epochs = reduce.graph.connectedNodes
-        .map(node => {
-          const info = {
-            id: node.key, // alias: epochRoot
-            previous: node.previous,
-            ...node.data[node.key]
-          }
-          info.epochKey = Buffer.from(info.epochKey, 'base64')
-          return info
-        })
-
-      cb(null, epochs)
-    })
-  }
-
-  function getMembers (epochRoot, cb) {
-    if (cb === undefined) return p(getMembers)(epochRoot)
-
-    getEpochMembers(ssb, epochRoot, cb)
   }
 
   return {
-    getEpochs,
-    getMembers,
+    getEpochs (groupId, cb) {
+      if (cb === undefined) return p(this.getEpochs)(groupId)
+
+      const getters = pluck(allGetters, ['author', 'epochKey'])
+      reduceEpochs(ssb, groupId, getters, (err, reduce) => {
+        if (err) return cb(clarify(err, 'Failed to resolve epoch @tangle/reduce'))
+
+        const epochs = reduce.graph.connectedNodes
+          .map(node => {
+            const info = {
+              id: node.key, // alias: epochRootId
+              previous: node.previous,
+              ...node.data[node.key]
+            }
+            info.epochKey = Buffer.from(info.epochKey, 'base64')
+            return info
+          })
+
+        cb(null, epochs)
+      })
+    },
+
+    getMembers (epochRootId, cb) {
+      if (cb === undefined) return p(this.getMembers)(epochRootId)
+
+      getMembers(ssb, epochRootId, cb)
+    },
+
+    getMissingMembers (groupId, cb) {
+      if (cb === undefined) return p(this.getMissingMembers)(groupId)
+
+      reduceEpochs(ssb, groupId, allGetters, (err, reduce) => {
+        if (err) return cb(clarify(err, 'Failed to resolve epoch @tangle/reduce'))
+
+        const result = reduce.graph.connectedNodes.reduce((acc, node) => {
+          // For each node (epoch) in the tangle, determine which feeds have
+          // historically been added / excluded.
+          const addedSoFar = new Set()
+          const excludedSoFar = new Set()
+          ;[node.key, ...reduce.graph.getHistory(node.key)]
+            .map(key => reduce.graph.getNode(key))
+            .forEach(historyNode => {
+              const { added, toExclude } = historyNode.data[historyNode.key].members
+              added.forEach(feedId => addedSoFar.add(feedId))
+
+              if (historyNode.key === node.key) return
+              // INFO node members toExclude is talking about what should happen
+              // *after* it in the graph, so if we're enquiring about a
+              // particular epoch, we don't include that epoch's toExclude
+              toExclude.forEach(feedId => excludedSoFar.add(feedId))
+            })
+
+          // Check if those who should be present are present
+          const shouldBePresent = difference(addedSoFar, excludedSoFar)
+          const currentMembers = new Set(node.data[node.key].members.added)
+          if (isSameSet(shouldBePresent, currentMembers)) return acc
+
+          // If find some missing, record this epoch and missing members
+          acc.push({
+            epoch: node.key, // alias: epochRootId
+            epochKey: Buffer.from(node.data[node.key].epochKey, 'base64'),
+            missing: [...difference(shouldBePresent, currentMembers)]
+          })
+          return acc
+        }, [])
+
+        cb(null, result)
+      })
+    }
   }
 }
 
 function reduceEpochs (ssb, groupId, getters = {}, cb) {
-  // getters is an Object of form:
-  // {
-  //   [fieldName]: fieldGetter(msg, cb)
-  // }
+  // - `groupId` *String* ssb-uri for a group
+  // - `getters` *Object* which describes which data fields you would like
+  //   added to each epoch, and an async getter to aquire the data.
+  //     - The getter is a function with signature `(epochRoot, cb)`.
+  //     - e.g.:
+  //       ```
+  //       const getters = {
+  //         author (epochRoot, cb) {
+  //           getRootFeedId(epochRoot.value.author, cb)
+  //         }
+  //       }
+  //       ```
+  // - `cb` *Function* a callback which receives a @tangle/reduce result.
+  //   This is an object which has produced a tangle of connected "nodes"
+  //   (which each "node" is an epoch here), and we can access the graph
+  //   and nodes under `resolve.graph` (which is a @tangle/graph object)
+
   ssb.box2.getGroupInfo(groupId, (err, info) => {
     if (err) return cb(clarify(err, 'Failed to get group info for ' + groupId))
 
+    // Fetch the tangle root
     ssb.db.get(info.root, (err, rootVal) => {
       if (err) return cb(clarify(err, 'Failed to load group root with id ' + info.root))
       if (!isInitRoot(rootVal)) return cb(clarify(new Error(isInitRoot.string), 'Malformed group/init root message'))
 
       const root = { key: info.root, value: rootVal }
 
+      // Fetch the tangle updates
       getTangleUpdates(ssb, 'epoch', info.root, (err, updates) => {
         if (err) return cb(clarify(err, 'Failed to updates of group epoch tangle'))
 
+        // Take each root/update and build an epoch "node" for our tangle
         pull(
-          pull.values([
-            root,
-            ...updates.filter(isInitEpoch)
-          ]),
+          pull.values([root, ...updates.filter(isInitEpoch)]),
           pull.asyncMap((msg, cb) => {
-            const epochRoot = toMsgURI(msg.key)
+            const epochRootId = toMsgURI(msg.key)
             const epochData = {}
+            const node = {
+              key: epochRootId,
+              previous: msg.value.content.tangles.epoch.previous,
+              data: {
+                [epochRootId]: epochData
+              }
+            }
 
-            // go through all the getters, get their info, and attach it to epochData
+            // Use out getters to attach desired data to our epoch "node"
             pull(
-              pull.keys(getters),
-              pull.asyncMap((fieldName, cb) => {
-                const getter = getters[fieldName]
+              pull.values(Object.entries(getters)),
+              pull.asyncMap(([fieldName, getter], cb) => {
                 getter(msg, (err, fieldData) => {
                   if (err) return cb(clarify(err, 'Failed to get epoch ' + fieldName))
                   epochData[fieldName] = fieldData
@@ -140,22 +210,17 @@ function reduceEpochs (ssb, groupId, getters = {}, cb) {
               pull.collect((err) => {
                 if (err) return cb(clarify(err, 'Failed to collect epoch data'))
 
-                cb(null, {
-                  key: epochRoot,
-                  previous: msg.value.content.tangles.epoch.previous,
-                  data: {
-                    [epochRoot]: epochData
-                  }
-                })
+                cb(null, node)
               })
             )
           }),
           pull.collect((err, nodes) => {
             if (err) return cb(clarify(err, 'Failure collecting epoch messages'))
 
+            // Finally reduce all of these epoch nodes with a tangle
             const reduce = new Reduce(strategy, { nodes })
-            // walk the graph and prune invalid links
             reduce.resolve()
+            // INFO this walks the graph and prunes disconnected nodes
 
             cb(null, reduce)
           })
@@ -164,32 +229,56 @@ function reduceEpochs (ssb, groupId, getters = {}, cb) {
     })
   })
 }
-function toMsgURI (id) {
-  return id.startsWith('%') ? fromMessageSigil(id) : id
-}
 
-function getEpochMembers (ssb, epochRoot, cb) {
-  const members = new Set()
+function getMembers (ssb, epochRootId, cb) {
+  epochRootId = toMsgURI(epochRootId)
+  const added = new Set()
   const toExclude = new Set()
 
   pull(
-    getTangleUpdates.stream(ssb, 'members', epochRoot),
+    getTangleUpdates.stream(ssb, 'members', epochRootId),
     pull.filter(msg => isAddMember(msg) || isExclude(msg)),
     pull.drain(
       msg => {
         const { type, recps, excludes } = msg.value.content
         if (type === 'group/add-member')
-          recps.slice(1).forEach(feedId => members.add(feedId))
+          recps.slice(1).forEach(feedId => added.add(feedId))
         else
           excludes.forEach(feedId => toExclude.add(feedId))
       },
       err => {
         if (err) return cb(clarify(err, 'Failed to resolve epoch membership'))
         cb(null, {
-          members: [...members],
+          added: [...added],
           toExclude: [...toExclude],
         })
       }
     )
   )
+}
+
+/* HELPERS */
+function toPattern (regexp) {
+  return regexp.toString().replace(/^\//, '').replace(/\/$/, '')
+}
+
+function toMsgURI (id) {
+  return id.startsWith('%') ? fromMessageSigil(id) : id
+}
+
+function pluck (obj, keys) {
+  return keys.reduce((acc, key) => {
+    acc[key] = obj[key]
+    return acc
+  }, {})
+}
+
+function isSameSet (a, b) {
+  if (a.size !== b.size) return false
+
+  for (const el of a) {
+    if (!b.has(el)) return false
+  }
+
+  return true
 }

--- a/lib/epochs.js
+++ b/lib/epochs.js
@@ -113,6 +113,10 @@ module.exports = function Epochs (ssb) {
       reduceEpochs(ssb, groupId, allGetters, (err, reduce) => {
         if (err) return cb(clarify(err, 'Failed to resolve epoch @tangle/reduce'))
 
+        if (reduce.graph.connectedNodes.length === 1) return cb(null, [])
+        // INFO if there is only one connectedNode, there is only a
+        // single epoch, so there's no need to check anything
+
         const result = reduce.graph.connectedNodes.reduce((acc, node) => {
           // For each node (epoch) in the tangle, determine which feeds have
           // historically been added / excluded.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "private-group-spec": "^6.0.0",
     "pull-paramap": "^1.2.2",
     "pull-stream": "^3.7.0",
+    "set.prototype.difference": "^1.0.2",
     "ssb-bfe": "^3.7.0",
     "ssb-box2": "^6.0.0",
     "ssb-crut": "^4.6.2",
@@ -73,8 +74,9 @@
   },
   "scripts": {
     "test:raw": "tape 'test/**/*.test.js'",
-    "test": "npm run test:raw | tap-arc",
+    "test:only": "if grep -r --exclude-dir=node_modules --exclude-dir=.git --color 'test\\.only' ; then exit 1; fi",
     "test:bail": "npm run test:raw | tap-arc --bail",
+    "test": "npm run test:raw | tap-arc && npm run test:only",
     "format-code": "prettier --write \"*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\"",
     "coverage": "c8 --reporter=lcov npm run test"

--- a/test/lib/epochs.test.js
+++ b/test/lib/epochs.test.js
@@ -69,7 +69,7 @@ test('lib/epochs (getEpochs, getMembers)', async t => {
     [{
       id: group.root,
       previous: null,
-      epochKey: group.writeKey.key,
+      secret: group.writeKey.key,
       author: aliceId
     }],
     'there is 1 epoch'
@@ -129,13 +129,13 @@ test('lib/epochs (getEpochs, getMembers)', async t => {
       {
         id: group.root,
         previous: null,
-        epochKey: group.writeKey.key,
+        secret: group.writeKey.key,
         author: aliceId
       },
       {
         id: lastGroupInitId,
         previous: [group.root],
-        epochKey: groupUpdated.writeKey.key,
+        secret: groupUpdated.writeKey.key,
         author: aliceId
       }
     ],
@@ -226,7 +226,7 @@ test('lib/epochs (getMissingMembers)', async t => {
     [
       {
         epoch: newEpoch.id,
-        epochKey: newEpoch.epochKey,
+        secret: newEpoch.secret,
         missing: [bobId]
       }
     ],


### PR DESCRIPTION
adds the ability to spot members missing.

**Minimal test at the moment:** hack so that a person is missed from being added to the new epoch. This detects that.

Algorithm: 
- for each epoch, collect all the people who have been added/ exluded up to that epoch
- check the group members are that group (added sofar - excluded sofar)
- if not, then note those members missing

COULD be good to test the forked case...