### PR TITLE
People added late to a group should get access to all epochs

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,10 +151,12 @@ module.exports = {
           // prettier-ignore
           if (err) return cb(clarify(err, "couldn't get root id of author of root msg"))
 
+          // TODO: one content/publish per epoch tip
           const content = {
             type: 'group/add-member',
             version: 'v2',
             groupKey: writeKey.key.toString('base64'),
+            // TODO: also attach every past secret for all predecessor epochs
             root,
             creator: rootAuthorId,
             recps: [groupId, ...feedIds],

--- a/lib/epochs.js
+++ b/lib/epochs.js
@@ -101,12 +101,12 @@ module.exports = function Epochs(ssb) {
       })
     },
 
-    getPreferredEpoch(groupId, cb) {
-      if (cb === undefined) return p(this.getPreferredEpoch).call(this, groupId)
+    getTipEpochs(groupId, cb) {
+      if (cb === undefined) return p(this.getTipEpochs).call(this, groupId)
 
       reduceEpochs(ssb, groupId, allGetters, (err, reduce) => {
-        if (err)
-          return cb(clarify(err, 'Failed to resolve epoch @tangle/reduce'))
+        // prettier-ignore
+        if (err) return cb(clarify(err, 'Failed to resolve epoch @tangle/reduce'))
 
         const tips = Object.keys(reduce.state).map((id) => {
           const info = {
@@ -118,6 +118,17 @@ module.exports = function Epochs(ssb) {
           info.members = new Set(info.members.toAdded)
           return info
         })
+
+        return cb(null, tips)
+      })
+    },
+
+    getPreferredEpoch(groupId, cb) {
+      if (cb === undefined) return p(this.getPreferredEpoch).call(this, groupId)
+
+      this.getTipEpochs(groupId, (err, tips) => {
+        // prettier-ignore
+        if (err) return cb(clarify(err, 'Failed to get tip epochs when finding preferred epoch'))
 
         let preferredEpoch
         if (tips.length === 1) preferredEpoch = tips[0]


### PR DESCRIPTION
Fixes https://github.com/ssbc/ssb-tribes2/issues/76

* [ ] add-member people to all tip epochs
* [ ] send added people all old secrets as well
* [ ] when joining a group, grab all tip invites (maybe we do already?) and all the secrets in them
* [ ] test that we add to all epoch tips?
* [ ] test that a late added member can read old stuff