### PR TITLE
added-late_CI_FIXES

### DIFF
--- a/lib/epochs.js
+++ b/lib/epochs.js
@@ -393,7 +393,6 @@ function Epochs(ssb) {
         pull(
           epochNodeStream(ssb, groupId, { getters, live }),
           pull.map((node) => {
-            console.log('adding epoch', node.id)
             reduce.addNodes([node])
             return true
           })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-tribes2",
-  "version": "0.4.0",
+  "version": "1.0.1",
   "description": "SSB private groups with ssb-db2",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
   "files": [
     "package.json.license",
     "LICENSES/*",
-    "lib/*.js",
+    "lib/**/*.js",
     "*.js"
   ],
   "dependencies": {
@@ -52,7 +52,7 @@
     "set.prototype.difference": "^1.0.2",
     "ssb-bfe": "^3.7.0",
     "ssb-box2": "^7.1.0",
-    "ssb-db2": "^7.1.0",
+    "ssb-db2": "^7.1.1",
     "ssb-meta-feeds": "^0.39.0",
     "ssb-private-group-keys": "^1.1.2",
     "ssb-ref": "^2.16.0",
@@ -68,7 +68,6 @@
     "rimraf": "^3.0.2",
     "secret-stack": "^6.4.1",
     "ssb-bendy-butt": "^1.0.2",
-    "ssb-caps": "^1.1.0",
     "ssb-classic": "^1.1.0",
     "ssb-ebt": "^9.1.2",
     "ssb-keys": "^8.5.0",

--- a/test/add-member.test.js
+++ b/test/add-member.test.js
@@ -258,204 +258,122 @@ test('addMembers adds to all the tip epochs and gives keys to all the old epochs
   // alice and bob remove carol at the same time, creating forked epochs
   // everyone still replicates and sees the fork
   // alice adds david to the group, and he should see both forks and the original epoch
-  const alice = Testbot({
-    keys: ssbKeys.generate(null, 'alice'),
-    mfSeed: Buffer.from(
-      '000000000000000000000000000000000000000000000000000000000000a1ce',
-      'hex'
-    ),
-    db2: {},
-  })
-  const bob = Testbot({
-    keys: ssbKeys.generate(null, 'bob'),
-    mfSeed: Buffer.from(
-      '0000000000000000000000000000000000000000000000000000000000000b0b',
-      'hex'
-    ),
-    db2: {},
-  })
-  const carol = Testbot({
-    keys: ssbKeys.generate(null, 'carol'),
-    mfSeed: Buffer.from(
-      '00000000000000000000000000000000000000000000000000000000000ca201',
-      'hex'
-    ),
-    db2: {},
-  })
-  const david = Testbot({
-    keys: ssbKeys.generate(null, 'david'),
-    mfSeed: Buffer.from(
-      '00000000000000000000000000000000000000000000000000000000000da71d',
-      'hex'
-    ),
-    db2: {},
-  })
 
-  await Promise.all([
-    alice.tribes2.start(),
-    bob.tribes2.start(),
-    carol.tribes2.start(),
-    david.tribes2.start(),
-  ])
-    .then(() => t.pass('clients started'))
-    .catch((err) => t.error(err))
+  const run = Run(t)
+
+  const alice = Testbot({ name: 'alice', db2: {} })
+  const bob = Testbot({ name: 'bob', db2: {} })
+  const carol = Testbot({ name: 'carol', db2: {} })
+  const david = Testbot({ name: 'david', db2: {} })
+
+  await run(
+    'clients started',
+    Promise.all([
+      alice.tribes2.start(),
+      bob.tribes2.start(),
+      carol.tribes2.start(),
+      david.tribes2.start(),
+    ])
+  )
 
   const [aliceRootId, bobRootId, carolRootId, davidRootId] = (
-    await Promise.all(
-      [alice, bob, carol, david].map((peer) => p(peer.metafeeds.findOrCreate)())
+    await run(
+      'got peer roots',
+      Promise.all(
+        [alice, bob, carol, david].map((peer) =>
+          p(peer.metafeeds.findOrCreate)()
+        )
+      )
     )
-      .then((res) => {
-        t.pass('got peer roots')
-        return res
-      })
-      .catch((err) => t.error(err))
   ).map((root) => root.id)
 
   async function replicateAll() {
-    await p(setTimeout)(4000)
+    await p(setTimeout)(2000)
 
-    const fail = (err, a, b) => {
-      console.error(`Replication between ${a} and ${b} failed:`, err)
-      t.error(err)
-    }
+    await replicate(alice, bob, carol, david)
+      .then(() => t.pass('replicated all'))
+      .catch((err) => t.error(err, 'replicated all'))
 
-    await replicate(alice, bob)
-      .then(() => t.pass('replicated alice and bob'))
-      .catch((err) => fail(err, 'alice', 'bob'))
-
-    await replicate(alice, carol)
-      .then(() => t.pass('replicated alice and carol'))
-      .catch((err) => fail(err, 'alice', 'carol'))
-
-    await replicate(alice, david)
-      .then(() => t.pass('replicated alice and david'))
-      .catch((err) => fail(err, 'alice', 'david'))
-
-    await replicate(bob, carol)
-      .then(() => t.pass('replicated bob and carol'))
-      .catch((err) => {
-        p(bob.metafeeds.printTree)(bobRootId, { id: true })
-        p(bob.metafeeds.printTree)(aliceRootId, { id: true })
-        p(carol.metafeeds.printTree)(carolRootId, { id: true })
-        p(carol.metafeeds.printTree)(aliceRootId, { id: true })
-        fail(err, 'bob', 'carol')
-      })
-
-    await replicate(carol, david)
-      .then(() => t.pass('replicated carol and david'))
-      .catch((err) => fail(err, 'carol', 'david'))
-
-    await replicate(david, alice)
-      .then(() => t.pass('replicated david and alice'))
-      .catch((err) => fail(err, 'david', 'alice'))
-
-    await p(setTimeout)(4000)
+    await p(setTimeout)(2000)
   }
 
   await replicateAll()
 
-  const { id: groupId, writeKey: firstEpochKey } = await alice.tribes2
-    .create()
-    .then((res) => {
-      t.pass('alice created group')
-      return res
-    })
-    .catch((err) => t.error(err))
+  const { id: groupId, writeKey: firstEpochKey } = await run(
+    'alice created group',
+    alice.tribes2.create()
+  )
   const firstEpochSecret = firstEpochKey.key.toString('base64')
 
-  const { key: firstEpochPostId } = await alice.tribes2
-    .publish({
+  const { key: firstEpochPostId } = await run(
+    'alice published in first epoch',
+    alice.tribes2.publish({
       type: 'test',
       text: 'first post',
       recps: [groupId],
     })
-    .then((res) => {
-      t.pass('alice published in first epoch')
-      return res
-    })
-    .catch((err) => t.error(err))
+  )
 
-  await alice.tribes2
-    .addMembers(groupId, [bobRootId, carolRootId])
-    .then(() => t.pass('alice added bob and carol'))
-    .catch((err) => t.error(err))
+  await run(
+    'alice added bob and carol',
+    alice.tribes2.addMembers(groupId, [bobRootId, carolRootId])
+  )
 
   await replicateAll()
 
-  await bob.tribes2
-    .acceptInvite(groupId)
-    .then(() => t.pass('bob accepted invite'))
-    .catch((err) => t.error(err))
+  await run('bob accepted invite', bob.tribes2.acceptInvite(groupId))
 
-  await Promise.all([
-    alice.tribes2.excludeMembers(groupId, [carolRootId]),
-    bob.tribes2.excludeMembers(groupId, [carolRootId]),
-  ])
-    .then(() => t.pass('alice and bob excluded carol'))
-    .catch((err) => t.error(err))
+  await run(
+    'alice and bob excluded carol',
+    Promise.all([
+      alice.tribes2.excludeMembers(groupId, [carolRootId]),
+      bob.tribes2.excludeMembers(groupId, [carolRootId]),
+    ])
+  )
 
-  const { key: aliceForkPostId } = await alice.tribes2
-    .publish({
+  const { key: aliceForkPostId } = await run(
+    'alice published in her fork',
+    alice.tribes2.publish({
       type: 'test',
       text: 'alice fork post',
       recps: [groupId],
     })
-    .then((res) => {
-      t.pass('alice published in her fork')
-      return res
-    })
-    .catch((err) => t.error(err))
-  const { writeKey: aliceForkKey } = await alice.tribes2
-    .get(groupId)
-    .then((res) => {
-      t.pass('alice got info on her fork')
-      return res
-    })
-    .catch((err) => t.error(err))
+  )
+
+  const { writeKey: aliceForkKey } = await run(
+    'alice got info on her fork',
+    alice.tribes2.get(groupId)
+  )
   const aliceForkSecret = aliceForkKey.key.toString('base64')
 
-  const { key: bobForkPostId } = await bob.tribes2
-    .publish({
+  const { key: bobForkPostId } = await run(
+    'bob posted in his fork',
+    bob.tribes2.publish({
       type: 'test',
       text: 'bob fork post',
       recps: [groupId],
     })
-    .then((res) => {
-      t.pass('bob posted in his fork')
-      return res
-    })
-    .catch((err) => t.error(err))
-  const { writeKey: bobForkKey } = await bob.tribes2
-    .get(groupId)
-    .then((res) => {
-      t.pass('bob got info on his fork')
-      return res
-    })
-    .catch((err) => t.error(err))
+  )
+
+  const { writeKey: bobForkKey } = await run(
+    'bob got info on his fork',
+    bob.tribes2.get(groupId)
+  )
   const bobForkSecret = bobForkKey.key.toString('base64')
 
   await replicateAll()
 
-  const addDavid = await alice.tribes2
-    .addMembers(groupId, [davidRootId])
-    .then((res) => {
-      t.pass('david got added to the group by alice')
-      return res
-    })
-    .catch((err) => t.error(err))
-
+  const addDavid = await run(
+    'david got added to the group by alice',
+    alice.tribes2.addMembers(groupId, [davidRootId])
+  )
   t.equal(addDavid.length, 2, 'David got added to both forks')
 
-  const adds = await Promise.all(
-    addDavid.map((add) => p(alice.db.get)(add.key))
+  const adds = await run(
+    'alice got her additions of david',
+    Promise.all(addDavid.map((add) => p(alice.db.get)(add.key)))
   )
-    .then((res) => {
-      t.pass('alice got her additions of david')
-      return res
-    })
-    .catch((err) => t.error(err))
   const addContents = adds.map((add) => add.content)
-
   const addAliceFork = addContents.find(
     (content) => content.secret === aliceForkSecret
   )
@@ -484,45 +402,34 @@ test('addMembers adds to all the tip epochs and gives keys to all the old epochs
     "gave david the secret to the initial epoch, in the addition to bob's fork"
   )
 
-  await replicate(alice, david)
-    .then(() => t.pass('replicated'))
-    .catch((err) => t.error(err))
+  await run('replicated', replicate(alice, david))
 
-  await david.tribes2
-    .acceptInvite(groupId)
-    .then(() => t.pass('david accepted invite'))
-    .catch((err) => t.error(err))
+  await run('david accepted invite', david.tribes2.acceptInvite(groupId))
 
-  const bobForkMsg = await p(david.db.get)(bobForkPostId)
-    .then((res) => {
-      t.pass("david got bob's post in his fork")
-      return res
-    })
-    .catch((err) => t.error(err))
+  const bobForkMsg = await run(
+    "david got bob's post in his fork",
+    p(david.db.get)(bobForkPostId)
+  )
   t.notEquals(
     typeof bobForkMsg.content,
     'string',
     "david decrypted the msg in bob's fork"
   )
 
-  const aliceForkMsg = await p(david.db.get)(aliceForkPostId)
-    .then((res) => {
-      t.pass("david got alice's post in her fork")
-      return res
-    })
-    .catch((err) => t.error(err))
+  const aliceForkMsg = await run(
+    "david got alice's post in her fork",
+    p(david.db.get)(aliceForkPostId)
+  )
   t.notEquals(
     typeof aliceForkMsg.content,
     'string',
     "david decrypted the msg in alice's fork"
   )
 
-  const firstEpochMsg = await p(david.db.get)(firstEpochPostId)
-    .then((res) => {
-      t.pass("david got alice's post in the initial epoch")
-      return res
-    })
-    .catch((err) => t.error(err))
+  const firstEpochMsg = await run(
+    "david got alice's post in the initial epoch",
+    p(david.db.get)(firstEpochPostId)
+  )
   t.notEquals(
     typeof firstEpochMsg.content,
     'string',
@@ -535,6 +442,6 @@ test('addMembers adds to all the tip epochs and gives keys to all the old epochs
     p(carol.close)(true),
     p(david.close)(true),
   ])
-    .then(() => t.pass('clients got closed'))
+    .then(() => t.pass('clients close'))
     .catch((err) => t.error(err))
 })

--- a/test/add-member.test.js
+++ b/test/add-member.test.js
@@ -261,10 +261,10 @@ test('addMembers adds to all the tip epochs and gives keys to all the old epochs
 
   const run = Run(t)
 
-  const alice = Testbot({ name: 'alice', db2: {} })
-  const bob = Testbot({ name: 'bob', db2: {} })
-  const carol = Testbot({ name: 'carol', db2: {} })
-  const david = Testbot({ name: 'david', db2: {} })
+  const alice = Testbot({ name: 'alice' })
+  const bob = Testbot({ name: 'bob' })
+  const carol = Testbot({ name: 'carol' })
+  const david = Testbot({ name: 'david' })
 
   await run(
     'clients started',

--- a/test/exclude-members.test.js
+++ b/test/exclude-members.test.js
@@ -620,21 +620,8 @@ test('Can exclude a person in a group with a lot of members', async (t) => {
 })
 
 test("restarting the client doesn't make us rejoin old stuff", async (t) => {
-  const alice = Testbot({
-    keys: ssbKeys.generate(null, 'alice'),
-    mfSeed: Buffer.from(
-      '000000000000000000000000000000000000000000000000000000000000a1ce',
-      'hex'
-    ),
-  })
-  let bob = Testbot({
-    name: 'bobrestart',
-    keys: ssbKeys.generate(null, 'bob'),
-    mfSeed: Buffer.from(
-      '0000000000000000000000000000000000000000000000000000000000000b0b',
-      'hex'
-    ),
-  })
+  const alice = Testbot({ name: 'alice' })
+  let bob = Testbot({ name: 'bob' })
 
   await Promise.all([alice.tribes2.start(), bob.tribes2.start()])
 
@@ -674,15 +661,7 @@ test("restarting the client doesn't make us rejoin old stuff", async (t) => {
   await p(bob.close)(true).then(() => t.pass("bob's client was closed"))
   await p(setTimeout)(500)
 
-  bob = Testbot({
-    rimraf: false,
-    name: 'bobrestart',
-    keys: ssbKeys.generate(null, 'bob'),
-    mfSeed: Buffer.from(
-      '0000000000000000000000000000000000000000000000000000000000000b0b',
-      'hex'
-    ),
-  })
+  bob = Testbot({ name: 'bob', rimraf: false })
   t.pass('bob got a new client')
   await bob.tribes2.start().then(() => t.pass('bob restarted'))
 

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2022 Mix Irving
+//
+// SPDX-License-Identifier: Unlicense
+
+module.exports = {
+  countGroupFeeds: require('./count-group-feeds'),
+  replicate: require('./replicate'),
+  Run: require('./run'),
+  Testbot: require('./testbot'),
+}

--- a/test/helpers/run.js
+++ b/test/helpers/run.js
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2022 Mix Irving
+//
+// SPDX-License-Identifier: Unlicense
+
+module.exports = function Run(t) {
+  // this function takes care of running a promise and logging
+  // (or testing) that it happens and any errors are handled
+  return async function run(label, promise, opts = {}) {
+    const { isTest = true, timer = false, logError = false } = opts
+
+    if (timer) console.time('> ' + label)
+    return promise
+      .then((res) => {
+        if (isTest) t.pass(label)
+        return res
+      })
+      .catch((err) => {
+        t.error(err, label)
+        if (logError) console.error(err)
+      })
+      .finally(() => timer && console.timeEnd('> ' + label))
+  }
+}

--- a/test/helpers/testbot.js
+++ b/test/helpers/testbot.js
@@ -7,14 +7,19 @@ const ssbKeys = require('ssb-keys')
 const bendyButtFormat = require('ssb-ebt/formats/bendy-butt')
 const path = require('path')
 const rimraf = require('rimraf')
-const caps = require('ssb-caps')
+const crypto = require('crypto')
+
+const shs = crypto.randomBytes(32)
+// ensure this is unique per run so peers can connect with one another but NOT
+// the same as the main-net ssb-caps (so this doesn't try gossiping with e.g.
+// manyverse instances)
 
 let count = 0
 
-/** opts.path      (optional)
- *  opts.name      (optional) - convenience method for deterministic opts.path
- *  opts.keys      (optional)
- *  opts.rimraf    (optional) - clear the directory before start (default: true)
+/** opts.path    (optional)
+ *  opts.name    (optional) - convenience method for deterministic opts.path
+ *  opts.keys    (optional)
+ *  opts.rimraf  (optional) - clear the directory before start (default: true)
  */
 module.exports = function createSbot(opts = {}) {
   const dir = opts.path || `/tmp/ssb-tribes2-tests-${opts.name || count++}`
@@ -22,7 +27,7 @@ module.exports = function createSbot(opts = {}) {
 
   const keys = opts.keys || ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
 
-  const stack = SecretStack({ appKey: caps.shs })
+  const stack = SecretStack({ caps: { shs } })
     .use(require('ssb-db2/core'))
     .use(require('ssb-classic'))
     .use(require('ssb-bendy-butt'))
@@ -30,6 +35,8 @@ module.exports = function createSbot(opts = {}) {
     .use(require('ssb-box2'))
     .use(require('ssb-db2/compat/feedstate'))
     .use(require('ssb-db2/compat/ebt'))
+    .use(require('ssb-db2/compat/db')) // for legacy replicate
+    .use(require('ssb-db2/compat/history-stream')) // for legacy replicate
     .use(require('ssb-ebt'))
     .use(require('../..'))
 

--- a/test/helpers/testbot.js
+++ b/test/helpers/testbot.js
@@ -88,6 +88,11 @@ function mfSeedFromName(name) {
         '00000000000000000000000000000000000000000000000000000000000da71d',
         'hex'
       )
+    case 'oscar':
+      return Buffer.from(
+        '0000000000000000000000000000000000000000000000000000000000005ca4',
+        'hex'
+      )
 
     default:
       throw new Error('no mfSeed set up for ' + name)

--- a/test/helpers/testbot.js
+++ b/test/helpers/testbot.js
@@ -25,7 +25,10 @@ module.exports = function createSbot(opts = {}) {
   const dir = opts.path || `/tmp/ssb-tribes2-tests-${opts.name || count++}`
   if (opts.rimraf !== false) rimraf.sync(dir)
 
-  const keys = opts.keys || ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  const keys =
+    opts.keys || opts.name
+      ? ssbKeys.generate(null, opts.name)
+      : ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
 
   const stack = SecretStack({ caps: { shs } })
     .use(require('ssb-db2/core'))
@@ -51,11 +54,42 @@ module.exports = function createSbot(opts = {}) {
       writeTimeout: 10,
     },
     metafeeds: {
-      seed: opts.mfSeed,
+      seed: opts.mfSeed || mfSeedFromName(opts.name),
     },
   })
 
+  sbot.name = opts.name
   sbot.ebt.registerFormat(bendyButtFormat)
 
   return sbot
+}
+
+function mfSeedFromName(name) {
+  if (!name) return
+
+  switch (name) {
+    case 'alice':
+      return Buffer.from(
+        '000000000000000000000000000000000000000000000000000000000000a1ce',
+        'hex'
+      )
+    case 'bob':
+      return Buffer.from(
+        '0000000000000000000000000000000000000000000000000000000000000b0b',
+        'hex'
+      )
+    case 'carol':
+      return Buffer.from(
+        '00000000000000000000000000000000000000000000000000000000000ca201',
+        'hex'
+      )
+    case 'david':
+      return Buffer.from(
+        '00000000000000000000000000000000000000000000000000000000000da71d',
+        'hex'
+      )
+
+    default:
+      throw new Error('no mfSeed set up for ' + name)
+  }
 }

--- a/test/lib/tangles/get-tangle-data.test.js
+++ b/test/lib/tangles/get-tangle-data.test.js
@@ -20,8 +20,7 @@ const Testbot = require('../../helpers/testbot')
 const replicate = require('../../helpers/replicate')
 
 test('get-tangle-data unit test', (t) => {
-  const name = `get-group-tangle-${Date.now()}`
-  const server = Testbot({ name })
+  const server = Testbot()
 
   server.metafeeds.findOrCreate(
     { purpose: 'group/additions' },

--- a/test/list-and-get.test.js
+++ b/test/list-and-get.test.js
@@ -11,9 +11,7 @@ const Testbot = require('./helpers/testbot')
 const replicate = require('./helpers/replicate')
 
 test('tribes.list + tribes.get', (t) => {
-  const name = `list-and-get-groups-${Date.now()}`
-  let server = Testbot({ name })
-  const keys = server.keys
+  let server = Testbot({ name: 'alice' })
 
   server.tribes2.create(null, (err, group) => {
     t.error(err, 'create group')
@@ -40,7 +38,7 @@ test('tribes.list + tribes.get', (t) => {
           server.close(true, (err) => {
             t.error(err, 'closes server')
 
-            server = Testbot({ name, rimraf: false, keys })
+            server = Testbot({ name: 'alice', rimraf: false })
             pull(
               server.tribes2.list(),
               pull.collect((err, newList) => {

--- a/test/prune-publish.test.js
+++ b/test/prune-publish.test.js
@@ -75,7 +75,7 @@ test(
         const content = { type: 'potato', count: i, recps: [group.id] }
         return ssb.tribes2.publish(content, null).then(() => {
           count++
-          if (count % 500 === 0) t.pass(count)
+          if (count % 1000 === 0) t.pass(count)
         })
       })
     )
@@ -84,6 +84,9 @@ test(
       })
       .catch(t.error)
 
+    await p(setTimeout)(1000)
     await p(ssb.close)(true)
+
+    t.end()
   }
 )


### PR DESCRIPTION
Wanted to get this passing reliably. Also changes `replicate` to "replicate all" by default.

The function I wrote goes through each pair of peers in a set (with repetition). Turns our the repetition doesn't cost anything to do, because the vector clock check is _so dang fast_

```
alice-bob   ▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨ 3279ms
alice-carol ▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨ 4147ms
alice-david ▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨ 5414ms
bob-alice   ▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨ 5385ms
bob-carol   ▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨ 5374ms
bob-david   ▨ 28ms
carol-alice ▨ 11ms
carol-bob   ▨ 6ms
carol-david ▨ 6ms
david-alice ▨ 5ms
david-bob   ▨ 5ms
david-carol ▨ 8ms
```
- see `alice-david` is slow the first time, but `david-alice` later is almost instantaneous.
- interestingly `alice-bob` and `bob-alice` are both slow ... this is because in between these alice has picked up more feeds from carol and david (I think?)